### PR TITLE
Re-implement memory features with memory row and indicator

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -8,7 +8,15 @@
         :parameters="finParameters"
         :calculated-parameter="calculatedParameter"
         :is-financial-mode="isFinancialMode"
+        :memory-active="!!memoryValue"
       />
+      <!-- Memory buttons row -->
+      <div class="memory-row">
+        <CalculatorButton label="MC" type="memory" @click="memoryClear" />
+        <CalculatorButton label="MR" type="memory" @click="memoryRecall" />
+        <CalculatorButton label="M-" type="memory" @click="memorySubtract" />
+        <CalculatorButton label="M+" type="memory" @click="memoryAdd" />
+      </div>
       <!-- FIN button at the top -->
       <div class="fin-section">
         <FinButtonMenu 
@@ -77,10 +85,34 @@ export default {
       currentParameter: null,
       calculatedParameter: '',
       inputDescription: '',
-      finParameters: null
+      finParameters: null,
+      // Memory state
+      memoryValue: 0
     }
   },
   methods: {
+    // Memory Operations
+    memoryAdd() {
+      const currentValue = parseFloat(this.displayValue)
+      if (!isNaN(currentValue)) {
+        this.memoryValue += currentValue
+      }
+    },
+    memorySubtract() {
+      const currentValue = parseFloat(this.displayValue)
+      if (!isNaN(currentValue)) {
+        this.memoryValue -= currentValue
+      }
+    },
+    memoryRecall() {
+      this.displayValue = String(this.memoryValue)
+      if (this.isFinancialMode && this.currentParameter) {
+        this.$refs.finMenu.assignParameterValue(this.currentParameter, this.displayValue)
+      }
+    },
+    memoryClear() {
+      this.memoryValue = 0
+    },
     handleInput(value) {
       if (this.isFinancialMode) {
         // Always update display value in financial mode
@@ -260,6 +292,14 @@ body {
   width: 320px;
   display: flex;
   flex-direction: column;
+}
+
+.memory-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  padding: 8px;
+  margin-bottom: 8px;
 }
 
 .calculator-grid {

--- a/src/components/CalculatorDisplay.vue
+++ b/src/components/CalculatorDisplay.vue
@@ -22,9 +22,12 @@
       </div>
       <!-- Current input display -->
       <div class="current-input">
-        <div v-if="description" class="input-description">
-          {{ description }}
-          <span v-if="isCalculatedValue" class="calculated-badge">Calculated</span>
+        <div class="input-description">
+          <div v-if="description">
+            {{ description }}
+            <span v-if="isCalculatedValue" class="calculated-badge">Calculated</span>
+          </div>
+          <div v-if="memoryActive" class="memory-indicator">M</div>
         </div>
         <div class="display-value" :class="{ 'with-description': description }">
           {{ formatValue(value) }}
@@ -59,6 +62,10 @@ export default {
       default: ''
     },
     isFinancialMode: {
+      type: Boolean,
+      default: false
+    },
+    memoryActive: {
       type: Boolean,
       default: false
     }
@@ -197,6 +204,15 @@ export default {
   color: white;
   padding: 2px 6px;
   border-radius: 4px;
+}
+
+.memory-indicator {
+  font-size: 0.8rem;
+  background-color: #2196f3;
+  color: white;
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin-left: auto;
 }
 
 .display-value {


### PR DESCRIPTION
Memory features have been successfully reimplemented and pushed to GitHub:

1. Added memory state and operations in App.vue:
   - Memory value state
   - M+, M-, MR, MC operations
   - Memory buttons row with proper styling

2. Added memory indicator in CalculatorDisplay.vue:
   - Memory active prop
   - M indicator with blue badge styling
   - Updated display layout

The memory features are working in the app, with both the memory buttons visible and the M indicator showing when memory has a value.